### PR TITLE
#10 Check if we can delete attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All Notable changes to `ElementFinder` will be documented in this file
 
+## Version 0.1.0-alpha.2
+- Deprecated `ElementFinder::attribute()`. Use `ElementFinder::value()` instead.
+- Skip `XpathExpression` creation. By default use Xpath. Use `CssExpression` only when needed.  
+
 ## Version 0.0.3
 - Feature #4 Use `DOMAttr::nodeValue` instead of `DOMAttr::value`    
 - BC #7 Refactor `Helper` class. Create `FormHelper`, `NodeHelper` and `StringHelper`    

--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -247,30 +247,13 @@
 
 
     /**
-     * ```
-     * // return all href elements
-     *
-     * $page->attribute('//a/@href');
-     *
-     * // get title of first link
-     * $page->attribute('//a[1]/@title')-item(0);
-     *
-     * ```
      * @deprecated
      * @param $xpath
      * @return StringCollection
      */
     public function attribute($xpath) {
       trigger_error('Deprecated', E_USER_DEPRECATED);
-      $items = $this->query($xpath);
-
-      $collection = new StringCollection();
-      foreach ($items as $item) {
-        /** @var \DOMAttr $item */
-        $collection->append($item->nodeValue);
-      }
-
-      return $collection;
+      return $this->value($xpath);
     }
 
 

--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -64,6 +64,7 @@
      */
     protected $loadErrors;
 
+
     /**
      *
      *
@@ -255,10 +256,12 @@
      * $page->attribute('//a[1]/@title')-item(0);
      *
      * ```
+     * @deprecated
      * @param $xpath
      * @return StringCollection
      */
     public function attribute($xpath) {
+      trigger_error('Deprecated', E_USER_DEPRECATED);
       $items = $this->query($xpath);
 
       $collection = new StringCollection();

--- a/src/Helper/FormHelper.php
+++ b/src/Helper/FormHelper.php
@@ -48,7 +48,7 @@
       # select
       $selectItems = $form->object('//select', true);
       foreach ($selectItems as $select) {
-        $name = $select->attribute('//select/@name')->item(0);
+        $name = $select->value('//select/@name')->item(0);
         $option = $select->value('//option[@selected]');
 
         if (!isset($option[0])) {

--- a/tests/ElementFinderTest.php
+++ b/tests/ElementFinderTest.php
@@ -55,7 +55,7 @@
     public function testAttributes() {
       $html = $this->getHtmlTestObject();
 
-      $links = $html->attribute("//a/@href");
+      $links = $html->value("//a/@href");
 
       $this->assertCount(1, $links);
 
@@ -114,12 +114,12 @@
     public function testDeleteAttribute() {
       $html = $this->getHtmlTestObject();
 
-      $title = $html->attribute('//a/@title')->getFirst();
+      $title = $html->value('//a/@title')->getFirst();
       $this->assertEquals('my blog', $title);
 
       $html->remove('//a/@title');
 
-      $title = $html->attribute('//a/@title')->getFirst();
+      $title = $html->value('//a/@title')->getFirst();
       $this->assertEmpty($title);
 
     }

--- a/tests/ObjectCollectionTest.php
+++ b/tests/ObjectCollectionTest.php
@@ -41,7 +41,7 @@
       $spanItems->replace('!span-(\d+)!', 'class-span--$1');
 
       foreach ($spanItems as $index => $item) {
-        $class = $item->attribute('//@class')->getFirst();
+        $class = $item->value('//@class')->getFirst();
         $expectClass = 'class-span--' . ($index + 1);
         $this->assertEquals($expectClass, $class);
       }
@@ -49,7 +49,7 @@
       $spanItems->replace('!class=".*"!U');
 
       foreach ($spanItems as $index => $item) {
-        $classAttributes = $item->attribute('//@class');
+        $classAttributes = $item->value('//@class');
         $this->assertCount(0, $classAttributes);
       }
 


### PR DESCRIPTION
To get attribute of a node use ElementFinder::value('//a/@href') instead of ElementFinder::attribute('//a/@href')

ElementFinder::attribute() is now deprecated