### PR TITLE
do not use the `saveXml` method if the current document type is HTML

### DIFF
--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -100,9 +100,9 @@ class ElementFinder implements ElementFinderInterface
         $result = [];
         foreach ($items as $node) {
             if ($outerContent) {
-                $result[] = NodeHelper::getOuterContent($node);
+                $result[] = NodeHelper::getOuterContent($node, $this->type);
             } else {
-                $result[] = NodeHelper::getInnerContent($node);
+                $result[] = NodeHelper::getInnerContent($node, $this->type);
             }
         }
         return new StringCollection($result);
@@ -180,8 +180,8 @@ class ElementFinder implements ElementFinderInterface
         foreach ($items as $node) {
             assert($node instanceof \DOMElement);
             $html = $outerHtml
-                ? NodeHelper::getOuterContent($node)
-                : NodeHelper::getInnerContent($node);
+                ? NodeHelper::getOuterContent($node, $this->type)
+                : NodeHelper::getInnerContent($node, $this->type);
             if (trim($html) === '') {
                 $html = '<html data-document-is-empty></html>';
             }

--- a/src/Helper/NodeHelper.php
+++ b/src/Helper/NodeHelper.php
@@ -4,30 +4,32 @@ declare(strict_types=1);
 
 namespace Xparse\ElementFinder\Helper;
 
+use Xparse\ElementFinder\ElementFinder;
+
 /**
  * @author Ivan Shcherbak <alotofall@gmail.com>
  */
 class NodeHelper
 {
-    final public static function getOuterContent(\DOMNode $node): string
+    final public static function getOuterContent(\DOMNode $node, int $documentType): string
     {
         $domDocument = new \DOMDocument('1.0');
         $b = $domDocument->importNode($node->cloneNode(true), true);
         /** @noinspection UnusedFunctionResultInspection */
         $domDocument->appendChild($b);
 
-        $content = $domDocument->saveHTML();
+        $content = $documentType === ElementFinder::DOCUMENT_XML ? $domDocument->saveXml() : $domDocument->saveHTML();
         $content = StringHelper::safeEncodeStr($content);
 
         return $content;
     }
 
 
-    final public static function getInnerContent(\DOMNode $itemObj): string
+    final public static function getInnerContent(\DOMNode $itemObj, int $documentType): string
     {
         $content = '';
         foreach ($itemObj->childNodes as $child) {
-            $content .= $child->ownerDocument->saveXML($child);
+            $content .= ($documentType === ElementFinder::DOCUMENT_XML ? $child->ownerDocument->saveXml($child) : $child->ownerDocument->saveHTML($child));
         }
         return StringHelper::safeEncodeStr($content);
     }


### PR DESCRIPTION
Hi 👋🏻 
Found a bug with incorrect execution of the `saveXml` method when the current document type is HTML.

Can repeat with a code:
`
      $html = '
<body> <style>\n
  *, div, td, p, b, u, span {\n
    font-family: tahoma, arial, sans-serif;\n
  }\n
</style> </body>';

      $f = new ElementFinder($html, ElementFinder::DOCUMENT_HTML);
      var_dump($f->content('*')->get(0));
`
You will receive something like this:
`
<style><![CDATA[\n
  *, div, td, p, b, u, span {\n
    font-family: tahoma, arial, sans-serif;\n
  }\n
]]></style>
`

`<![CDATA` was appended because of the `saveXml` method execution in `NodeHelper::getInnerContent` method.