### PR TITLE
Remove deprecated usage of function

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,4 @@
 phpunit.xml.dist   export-ignore
 tests              export-ignore
 docs               export-ignore
-
+.phpunit.result.cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: '8.1'
-            main: true
           - php-version: '8.2'
+            main: true
           - php-version: '8.3'
           - php-version: '8.4'
             nightly: true
@@ -44,7 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --dev
+        run: composer install --prefer-dist
 
       - name: Run tests
         continue-on-error: ${{ matrix.nightly }}

--- a/.idea/ElementFinder.iml
+++ b/.idea/ElementFinder.iml
@@ -3,28 +3,20 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Xparse\ElementFinder\" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/nikic/php-parser" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-invoker" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/container" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/event-dispatcher" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/cli-parser" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/complexity" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/lines-of-code" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/type" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/deprecation-contracts" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/event-dispatcher-contracts" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-intl-grapheme" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-intl-normalizer" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php80" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php81" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/service-contracts" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/string" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/phpstan/phpstan" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/rector/rector" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/css-selector" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symplify/easy-coding-standard" />
+      <sourceFolder url="file://$MODULE_DIR$/./tests" isTestSource="true" packagePrefix="Test\Xparse\ElementFinder\" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/clue/ndjson-react" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/evenement/evenement" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/fidry/cpu-core-counter" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/cache" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/child-process" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/dns" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/event-loop" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/promise" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/socket" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/react/stream" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/staabm/side-effects-detector" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -75,6 +75,17 @@
       <path value="$PROJECT_DIR$/vendor/symfony/css-selector" />
       <path value="$PROJECT_DIR$/vendor/symplify/easy-coding-standard" />
       <path value="$PROJECT_DIR$/vendor/xparse/expression-translator" />
+      <path value="$PROJECT_DIR$/vendor/evenement/evenement" />
+      <path value="$PROJECT_DIR$/vendor/clue/ndjson-react" />
+      <path value="$PROJECT_DIR$/vendor/fidry/cpu-core-counter" />
+      <path value="$PROJECT_DIR$/vendor/react/event-loop" />
+      <path value="$PROJECT_DIR$/vendor/react/cache" />
+      <path value="$PROJECT_DIR$/vendor/react/stream" />
+      <path value="$PROJECT_DIR$/vendor/react/promise" />
+      <path value="$PROJECT_DIR$/vendor/react/dns" />
+      <path value="$PROJECT_DIR$/vendor/react/socket" />
+      <path value="$PROJECT_DIR$/vendor/react/child-process" />
+      <path value="$PROJECT_DIR$/vendor/staabm/side-effects-detector" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.2">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 All Notable changes to `ElementFinder` will be documented in this file
+## 3.0 [Unreleased]
+- Move to php 8.2
 
 ## 2.0.0 [2023-01-11]
 - Move to php 8.1

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
   "require": {
     "php": "^8.2",
     "ext-dom": "*",
-    "ext-iconv": "*",
     "ext-libxml": "*",
     "symfony/css-selector": "^7.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
   "require": {
     "php": "^8.2",
     "ext-dom": "*",
+    "ext-iconv": "*",
     "ext-libxml": "*",
     "symfony/css-selector": "^7.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-dom": "*",
     "ext-libxml": "*",
     "symfony/css-selector": "^7.1"
@@ -35,7 +35,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Test\\Xparse\\ElementFinder\\": "tests"
+      "Test\\Xparse\\ElementFinder\\": "./tests"
     }
   },
   "config": {

--- a/ecs.php
+++ b/ecs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -14,7 +15,11 @@ return function (ECSConfig $ecsConfig): void {
         __FILE__,
     ]);
 
-    $ecsConfig->rules([NoUnusedImportsFixer::class, VoidReturnFixer::class]);
+    $ecsConfig->rules([
+        NoUnusedImportsFixer::class,
+        VoidReturnFixer::class,
+        DeclareStrictTypesFixer::class,
+    ]);
 
     // this way you can add sets - group of rules
     $ecsConfig->sets([SetList::SPACES, SetList::ARRAY, SetList::DOCBLOCK, SetList::NAMESPACES, SetList::COMMENTS, SetList::PSR_12]);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,19 +2,25 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php"
         colors="true"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
         <report>
             <clover outputFile=".tmp/clover.xml"/>
         </report>
     </coverage>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory>tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -215,18 +215,18 @@ class ElementFinder implements ElementFinderInterface
         if (static::DOCUMENT_HTML === $this->type) {
             $data = StringHelper::safeEncodeStr($data);
 
-            $encodedData = mb_encode_numericentity(
+            //Analogue of mb_convert_encoding($data, 'HTML-ENTITIES', 'UTF-8')
+            //Usage of mb_convert_encoding with encoding to HTML_ENTITIES is deprecated since php version 8.2
+            //When passing data to ElementFinder in an encoding other than UTF-8, any unrecognized characters will be ignored
+            $data = mb_encode_numericentity(
                 htmlspecialchars_decode(
-                    htmlentities($data, ENT_NOQUOTES, 'UTF-8', false)
+                    htmlentities($data, ENT_NOQUOTES | ENT_IGNORE, 'UTF-8', false)
                     , ENT_NOQUOTES
                 ), [0x80, 0x10FFFF, 0, ~0],
                 'UTF-8'
             );
-            if (!$encodedData) {
-                $encodedData = iconv('UTF-8', 'UTF-8//IGNORE', $data);
-            }
 
-            $this->dom->loadHTML($encodedData, LIBXML_NOCDATA & LIBXML_NOERROR);
+            $this->dom->loadHTML($data, LIBXML_NOCDATA & LIBXML_NOERROR);
         } elseif (static::DOCUMENT_XML === $this->type) {
             $this->dom->loadXML($data, LIBXML_NOCDATA & LIBXML_NOERROR);
         } else {

--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -220,9 +220,10 @@ class ElementFinder implements ElementFinderInterface
             //When passing data to ElementFinder in an encoding other than UTF-8, any unrecognized characters will be ignored
             $data = mb_encode_numericentity(
                 htmlspecialchars_decode(
-                    htmlentities($data, ENT_NOQUOTES | ENT_IGNORE, 'UTF-8', false)
-                    , ENT_NOQUOTES
-                ), [0x80, 0x10FFFF, 0, ~0],
+                    htmlentities($data, ENT_NOQUOTES | ENT_IGNORE, 'UTF-8', false),
+                    ENT_NOQUOTES
+                ),
+                [0x80, 0x10FFFF, 0, ~0],
                 'UTF-8'
             );
 

--- a/src/ElementFinder.php
+++ b/src/ElementFinder.php
@@ -214,8 +214,19 @@ class ElementFinder implements ElementFinderInterface
 
         if (static::DOCUMENT_HTML === $this->type) {
             $data = StringHelper::safeEncodeStr($data);
-            $data = mb_convert_encoding($data, 'HTML-ENTITIES', 'UTF-8');
-            $this->dom->loadHTML($data, LIBXML_NOCDATA & LIBXML_NOERROR);
+
+            $encodedData = mb_encode_numericentity(
+                htmlspecialchars_decode(
+                    htmlentities($data, ENT_NOQUOTES, 'UTF-8', false)
+                    , ENT_NOQUOTES
+                ), [0x80, 0x10FFFF, 0, ~0],
+                'UTF-8'
+            );
+            if (!$encodedData) {
+                $encodedData = iconv('UTF-8', 'UTF-8//IGNORE', $data);
+            }
+
+            $this->dom->loadHTML($encodedData, LIBXML_NOCDATA & LIBXML_NOERROR);
         } elseif (static::DOCUMENT_XML === $this->type) {
             $this->dom->loadXML($data, LIBXML_NOCDATA & LIBXML_NOERROR);
         } else {

--- a/tests/Collection/Filters/StringFilter/RegexStringFilterTest.php
+++ b/tests/Collection/Filters/StringFilter/RegexStringFilterTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Tests\Xparse\ElementFinder\Collection\Filters\StringFilter;
+declare(strict_types=1);
+
+namespace Test\Xparse\ElementFinder\Collection\Filters\StringFilter;
 
 use PHPUnit\Framework\TestCase;
 use Xparse\ElementFinder\Collection\Filters\StringFilter\RegexStringFilter;
 
-class RegexStringFilterTest extends TestCase
+final class RegexStringFilterTest extends TestCase
 {
     public function testRegexSuccess(): void
     {

--- a/tests/Collection/Modify/StringModify/RegexReplaceTest.php
+++ b/tests/Collection/Modify/StringModify/RegexReplaceTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace Tests\Xparse\ElementFinder\Collection\Modify\StringModify;
+declare(strict_types=1);
+
+namespace Test\Xparse\ElementFinder\Collection\Modify\StringModify;
 
 use PHPUnit\Framework\TestCase;
 use Xparse\ElementFinder\Collection\Modify\StringModify\RegexReplace;
 use Xparse\ElementFinder\Collection\StringCollection;
 
-class RegexReplaceTest extends TestCase
+final class RegexReplaceTest extends TestCase
 {
     public function testReplace(): void
     {

--- a/tests/Collection/StringCollectionTest.php
+++ b/tests/Collection/StringCollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Xparse\ElementFinder\Collection;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Test\Xparse\ElementFinder\Collection\Dummy\JoinedBy;
 use Test\Xparse\ElementFinder\Collection\Dummy\WithLetterFilter;
@@ -12,7 +13,7 @@ use Xparse\ElementFinder\Collection\StringCollection;
 /**
  * @author Ivan Shcherbak <alotofall@gmail.com>
  */
-class StringCollectionTest extends TestCase
+final class StringCollectionTest extends TestCase
 {
     public function testInvalidObjectIndex(): void
     {
@@ -87,10 +88,12 @@ class StringCollectionTest extends TestCase
     {
         $collection = (new StringCollection([
             1 => 'a',
-        ]))->merge(new StringCollection([
-            1 => 'b',
-            'c',
-        ]));
+        ]))->merge(
+            new StringCollection([
+                1 => 'b',
+                'c',
+            ])
+        );
         self::assertSame(['a', 'b', 'c'], $collection->all());
     }
 
@@ -128,7 +131,8 @@ class StringCollectionTest extends TestCase
 
         self::assertSame(
             [
-                'bar', 'baz',
+                'bar',
+                'baz',
             ],
             $collection->all()
         );
@@ -148,9 +152,7 @@ class StringCollectionTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider lastDataProvider
-     */
+    #[DataProvider('lastDataProvider')]
     public function testLast(array $items, mixed $expected): void
     {
         $collection = new StringCollection($items);

--- a/tests/CssExpressionTranslator/CssExpressionTranslatorTest.php
+++ b/tests/CssExpressionTranslator/CssExpressionTranslatorTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Xparse\ElementFinder\CssExpressionTranslator\Test;
+namespace Test\Xparse\ElementFinder\CssExpressionTranslator;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Xparse\ElementFinder\CssExpressionTranslator\CssExpressionTranslator;
 
@@ -15,7 +16,7 @@ class CssExpressionTranslatorTest extends TestCase
     /**
      * @return string[][]
      */
-    final public function getConvertWithAttributesDataProvider(): array
+    final public static function getConvertWithAttributesDataProvider(): array
     {
         return [
             ['a', 'descendant-or-self::a'],
@@ -26,9 +27,7 @@ class CssExpressionTranslatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getConvertWithAttributesDataProvider
-     */
+    #[DataProvider('getConvertWithAttributesDataProvider')]
     final public function testConvertWithAttributes(string $input, string $expect): void
     {
         self::assertSame(

--- a/tests/CssExpressionTranslator/CssOrXpathExpressionTranslatorTest.php
+++ b/tests/CssExpressionTranslator/CssOrXpathExpressionTranslatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test\Xparse\ElementFinder\CssExpressionTranslator;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Xparse\ElementFinder\CssExpressionTranslator\CssOrXpathExpressionTranslator;
 
@@ -16,7 +17,7 @@ final class CssOrXpathExpressionTranslatorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function getQueriesDataProvider(): array
+    public static function getQueriesDataProvider(): array
     {
         return [
             [
@@ -90,9 +91,7 @@ final class CssOrXpathExpressionTranslatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getQueriesDataProvider
-     */
+    #[DataProvider('getQueriesDataProvider')]
     public function testQueries(string $input, string $expect): void
     {
         $output = (new CssOrXpathExpressionTranslator())

--- a/tests/Dummy/ItemsByClassExpressionTranslator.php
+++ b/tests/Dummy/ItemsByClassExpressionTranslator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Xparse\ElementFinder\Dummy;
 
 use Xparse\ElementFinder\ExpressionTranslator\ExpressionTranslatorInterface;

--- a/tests/ElementFinderTest.php
+++ b/tests/ElementFinderTest.php
@@ -533,11 +533,7 @@ final class ElementFinderTest extends TestCase
                 'Текст текст text',
             ],
             [
-                (string)mb_convert_encoding('<body>Текст текст text</body>', 'WINDOWS-1251', 'UTF-8'),
-                '  text',
-            ],
-            [
-                (string)mb_convert_encoding('<body>Текст текст text</body>', 'ISO-8859-5', 'UTF-8'),
+                '<body>&#4294967295;&#4294967295;&#4294967295;&#4294967295;&#4294967295; &#4294967295;&#4294967295;&#4294967295;&#4294967295;&#4294967295; text</body>',
                 '  text',
             ],
         ];

--- a/tests/ElementFinderTest.php
+++ b/tests/ElementFinderTest.php
@@ -521,7 +521,6 @@ final class ElementFinderTest extends TestCase
       ';
     }
 
-
     /**
      * @return string[][]
      */
@@ -538,7 +537,6 @@ final class ElementFinderTest extends TestCase
             ],
         ];
     }
-
 
     #[DataProvider('getDifferentEncodingsSupportDataProvider')]
     public function testDifferentEncodingsSupport(string $html, string $bodyText): void

--- a/tests/ElementFinderTest.php
+++ b/tests/ElementFinderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test\Xparse\ElementFinder;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Test\Xparse\ElementFinder\Dummy\ItemsByClassExpressionTranslator;
@@ -518,5 +519,37 @@ final class ElementFinderTest extends TestCase
           </food>
       </breakfast_menu>
       ';
+    }
+
+
+    /**
+     * @return string[][]
+     */
+    public static function getDifferentEncodingsSupportDataProvider(): array
+    {
+        return [
+            [
+                '<body>Текст текст text</body>',
+                'Текст текст text',
+            ],
+            [
+                (string)mb_convert_encoding('<body>Текст текст text</body>', 'WINDOWS-1251', 'UTF-8'),
+                '  text',
+            ],
+            [
+                (string)mb_convert_encoding('<body>Текст текст text</body>', 'ISO-8859-5', 'UTF-8'),
+                '  text',
+            ],
+        ];
+    }
+
+
+    #[DataProvider('getDifferentEncodingsSupportDataProvider')]
+    public function testDifferentEncodingsSupport(string $html, string $bodyText): void
+    {
+        $page = new ElementFinder($html);
+        $pageBodyText = $page->content('//body')->first();
+        self::assertInstanceOf(ElementFinder::class, $page);
+        self::assertEquals($bodyText, $pageBodyText);
     }
 }

--- a/tests/Helper/FormHelperTest.php
+++ b/tests/Helper/FormHelperTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Xparse\ElementFinder\Helper;
+namespace Test\Xparse\ElementFinder\Helper;
 
 use Exception;
 use PHPUnit\Framework\TestCase;

--- a/tests/Helper/NodeHelperTest.php
+++ b/tests/Helper/NodeHelperTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Xparse\ElementFinder\Helper;
+namespace Test\Xparse\ElementFinder\Helper;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;

--- a/tests/Helper/StringHelperTest.php
+++ b/tests/Helper/StringHelperTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Xparse\ElementFinder\Helper;
+namespace Test\Xparse\ElementFinder\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Xparse\ElementFinder\Helper\StringHelper;
@@ -10,7 +10,7 @@ use Xparse\ElementFinder\Helper\StringHelper;
 /**
  * @author Ivan Shcherbak <alotofall@gmail.com>
  */
-class StringHelperTest extends TestCase
+final class StringHelperTest extends TestCase
 {
     public function testEncode(): void
     {


### PR DESCRIPTION
The reason for the changes is that the encoding in html-entities is deprecated for all MBString functions starting with PHP 8.2. An alternative that was used as a replacement was suggested here: https://github.com/symfony/symfony/issues/44281#issuecomment-1647665965